### PR TITLE
Refactor: ScanLines accepts []io.Reader as input

### DIFF
--- a/cmd/sort/main.go
+++ b/cmd/sort/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/Prucek/GNU_go_sort/internal/parse"
 	"github.com/Prucek/GNU_go_sort/internal/sort"
+	"github.com/Prucek/GNU_go_sort/internal/utils/slices"
 	"github.com/Prucek/GNU_go_sort/tools"
-	"os"
 )
 
 func main() {
@@ -15,7 +17,20 @@ func main() {
 	//naive := parse.SortAlgorithm{FnAppend: tools.AppendWrapper, FnSort: sort.Lines}
 	binary := parse.SortAlgorithm{FnAppend: sort.BinarySearchAppend, FnSort: tools.EmptySortWrapper}
 
-	lines, err := parse.ScanLines(arg, binary)
+	files, err := arg.OpenFiles()
+	defer func() {
+		for _, f := range files {
+			if err := f.Close(); err != nil {
+				fmt.Println(err)
+				os.Exit(2)
+			}
+		}
+	}()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(2)
+	}
+	lines, err = parse.ScanLines(slices.ToReaders(files), binary)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(2)

--- a/internal/parse/arguments.go
+++ b/internal/parse/arguments.go
@@ -1,12 +1,19 @@
 package parse
 
 import (
+	"errors"
 	"flag"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/Prucek/GNU_go_sort/internal/validate"
 )
 
 type Options struct {
 	ReverseFlag bool
 	Files       []string
+	fromStdin   bool
 }
 
 func optionFlags(ops *Options) {
@@ -20,9 +27,32 @@ func Arguments() *Options {
 	optionFlags(&ops)
 	ops.Files = flag.Args()
 	if len(ops.Files) == 0 || (len(ops.Files) == 1 && ops.Files[0] == "-") {
-		READ_STDIN = true
-	} else if len(ops.Files) > 0 {
-		READ_STDIN = false
+		ops.fromStdin = true
 	}
 	return &ops
+}
+
+func (o *Options) OpenFiles() ([]io.ReadCloser, error) {
+	if o.fromStdin {
+		return []io.ReadCloser{io.NopCloser(os.Stdin)}, nil
+	}
+	errMsgs := make([]string, 0, len(o.Files))
+	files := make([]io.ReadCloser, 0, len(o.Files))
+	for _, filename := range o.Files {
+		if err := validate.IsFile(filename); err != nil {
+			errMsgs = append(errMsgs, err.Error())
+			continue
+		}
+		f, err := os.Open(filename)
+		if err != nil {
+			errMsgs = append(errMsgs, err.Error())
+			continue
+		}
+		files = append(files, f)
+	}
+	var err error
+	if len(errMsgs) > 0 {
+		err = errors.New(strings.Join(errMsgs, ", "))
+	}
+	return files, err
 }

--- a/internal/parse/read_test.go
+++ b/internal/parse/read_test.go
@@ -1,9 +1,12 @@
 package parse
 
 import (
-	"github.com/Prucek/GNU_go_sort/internal/sort"
-	"github.com/Prucek/GNU_go_sort/tools"
+	"io"
 	"testing"
+
+	"github.com/Prucek/GNU_go_sort/internal/sort"
+	"github.com/Prucek/GNU_go_sort/internal/utils/slices"
+	"github.com/Prucek/GNU_go_sort/tools"
 )
 
 var ops = &Options{Files: []string{"read.go", "arguments.go", "read_test.go"}}
@@ -11,8 +14,13 @@ var naive = SortAlgorithm{FnAppend: tools.AppendWrapper, FnSort: sort.Lines}
 var binary = SortAlgorithm{FnAppend: sort.BinarySearchAppend, FnSort: tools.EmptySortWrapper}
 
 func BenchmarkScanLinesBinary(b *testing.B) {
+	files, err := ops.OpenFiles()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer closeOrFail(b, files)
 	for i := 0; i < b.N; i++ {
-		_, err := ScanLines(ops, binary)
+		_, err := ScanLines(slices.ToReaders(files), binary)
 		if err != nil {
 			return
 		}
@@ -21,10 +29,23 @@ func BenchmarkScanLinesBinary(b *testing.B) {
 }
 
 func BenchmarkScanLinesNaive(b *testing.B) {
+	files, err := ops.OpenFiles()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer closeOrFail(b, files)
 	for i := 0; i < b.N; i++ {
-		_, err := ScanLines(ops, naive)
+		_, err := ScanLines(slices.ToReaders(files), naive)
 		if err != nil {
 			return
+		}
+	}
+}
+
+func closeOrFail(b *testing.B, files []io.ReadCloser) {
+	for _, f := range files {
+		if err := f.Close(); err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/internal/utils/slices/generics.go
+++ b/internal/utils/slices/generics.go
@@ -1,0 +1,12 @@
+package slices
+
+import "io"
+
+// TODO: consider using generics (if possible) to rewrite this
+func ToReaders(xs []io.ReadCloser) []io.Reader {
+	ys := make([]io.Reader, 0, len(xs))
+	for _, x := range xs {
+		ys = append(ys, x)
+	}
+	return ys
+}


### PR DESCRIPTION
I've refactored the code a little bit so that now `ScanLines` accepts a more generics `[]io.Reader` and just reads each one of them.
`Options` is responsible to open the files and it makes a distinction between `stdin` and real files.