### PR TITLE
Add in-repo ci-operator config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,19 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.21
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: unit
+  commands: go test ./...
+  container:
+    from: src
+zz_generated_metadata:
+  org: Prucek
+  repo: GNU_go_sort
+  branch: master


### PR DESCRIPTION
## Summary

- Add `.ci-operator.yaml` for in-repo CI config
- Tests the in-repo-config-plugin auto-detection of new tests

The plugin should detect the new `unit` test and create an ephemeral ProwJob.